### PR TITLE
Add schema token

### DIFF
--- a/src/__tests__/exports.js
+++ b/src/__tests__/exports.js
@@ -1,0 +1,11 @@
+// @flow
+
+import test from 'tape-cup';
+import App, {ApolloClientToken, GraphQLSchemaToken} from '../index.js';
+
+test('fusion-tokens exports', t => {
+  t.ok(ApolloClientToken, 'exports ApolloClientToken');
+  t.ok(GraphQLSchemaToken, 'exports GraphQLSchemaToken');
+  t.ok(App, 'exports App');
+  t.end();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,10 @@ export const ApolloClientToken: Token<ApolloClient> = createToken(
   'ApolloClientToken'
 );
 
+export const GraphQLSchemaToken: Token<string> = createToken(
+  'GraphQlSchemaToken'
+);
+
 export default class App extends CoreApp {
   constructor(root: Element<*>) {
     const renderer = createPlugin({


### PR DESCRIPTION
Adds a new token, `GraphQLSchemaToken`, which can be used for both client LocalLink and a GraphQL handler plugin.