### PR TITLE
Export ApolloContextToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-tests/
 coverage/
 .nyc_output/
 
+.vscode
 .DS_Store
 npm-debug.log
 yarn-error.log

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export const ApolloClientToken: Token<ApolloClient> = createToken(
   'ApolloClientToken'
 );
 
-export const ApolloContextToken: Token<ApolloClient> = createToken(
+export const ApolloContextToken: Token<() => mixed | mixed> = createToken(
   'ApolloContextToken'
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,10 @@ export const ApolloClientToken: Token<ApolloClient> = createToken(
   'ApolloClientToken'
 );
 
+export const ApolloContextToken: Token<ApolloClient> = createToken(
+  'ApolloContextToken'
+);
+
 export const GraphQLSchemaToken: Token<string> = createToken(
   'GraphQlSchemaToken'
 );


### PR DESCRIPTION
There currently isn't a way to configure the Apollo context (provided to resolvers).

This PR exports a token which applications may use to configure `fusion-apollo-universal-client` and `fusion-plugin-apollo-server`.