### PR TITLE
Enable caching and context for fine-grained usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,13 @@
     "fusion-core": "^1.0.0",
     "react": "16.x",
     "react-apollo": "^2.0.4",
-    "react-dom": "16.x"
+    "react-dom": "16.x",
   },
   "engines": {
     "node": ">= 8.9.0"
   },
   "dependencies": {
-    "fusion-react": "^1.1.0"
+    "fusion-react": "^1.1.0",
+    "apollo-cache-inmemory": "^1.2.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "fusion-core": "^1.0.0",
     "react": "16.x",
     "react-apollo": "^2.0.4",
-    "react-dom": "16.x",
+    "react-dom": "16.x"
   },
   "engines": {
     "node": ">= 8.9.0"

--- a/src/index.js
+++ b/src/index.js
@@ -80,10 +80,12 @@ export default class App extends CoreApp {
 
           // Deserialize initial state for the browser
           let initialState = null;
+          let cache = null;
           if (__BROWSER__) {
             const apolloState = document.getElementById('__APOLLO_STATE__');
             if (apolloState) {
               initialState = JSON.parse(unescape(apolloState.textContent));
+              cache = apolloCache.restore(initialState);
             }
           }
 
@@ -94,7 +96,7 @@ export default class App extends CoreApp {
               <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
             );
           } else {        
-            const cache = apolloCache.restore(initialState);
+            // Create React Context and use cache to create client instead of initialState
             const ApolloContext = React.createContext('ApolloContext');
             const client = getApolloClient(ctx, cache);
             ctx.element = (

--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,9 @@ type ApolloClientType = mixed;
 
 type TCache = mixed
 
-export type ApolloClient<TStateOrCache> = (
+export type ApolloClient<TInitialState> = (
   ctx: Context,
-  cache: TCache,
+  initialState: TInitialState
 ) => ApolloClientType;
 
 export const ApolloClientToken: Token<ApolloClient<mixed>> = createToken(

--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,8 @@ export type ApolloClient<TStateOrCache> = (
   cache: TCache,
 ) => ApolloClientType;
 
-export const GetApolloClientToken: Token<ApolloClient<mixed>> = createToken(
-  'GetApolloClientToken'
+export const ApolloClientToken: Token<ApolloClient<mixed>> = createToken(
+  'ApolloClientToken'
 );
 
 export type ApolloContext<T> = (Context => T) | T;
@@ -63,7 +63,6 @@ export default class App extends CoreApp {
     const renderer = createPlugin({
       deps: {
         getApolloClient: GetApolloClientToken,
-        apolloCache: ApolloCacheToken = new InMemoryCache(),
       },
       provides() {
         return el => {
@@ -72,7 +71,7 @@ export default class App extends CoreApp {
           });
         };
       },
-      middleware({getApolloClient, apolloCache}) {
+      middleware({getApolloClient}) {
         // This is required to set apollo client/root on context before creating the client.
         return (ctx, next) => {
           if (!ctx.element) {
@@ -81,15 +80,14 @@ export default class App extends CoreApp {
           
           // Deserialize initial state for the browser
           let initialState = null;
-          let cache = apolloCache;
+          let cache = client.cache;
           let client = getApolloClient(ctx, cache);
                               
           if (__BROWSER__) {
             const apolloState = document.getElementById('__APOLLO_STATE__');
             if (apolloState) {
-              initialState = JSON.parse(unescape(apolloState.textContent));
-              cache = apolloCache.restore(initialState);
-              client = getApolloClient(ctx, cache);
+              initialState = JSON.parse(unescape(apolloState.textContent));             
+              client = getApolloClient(ctx, initialState);
             }
           }
           

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,6 @@ import {
 import type {Element} from 'react';
 import type {Context, Token} from 'fusion-core';
 
-import {InMemoryCache} from 'apollo-cache-inmemory';
-
 import serverRender from './server';
 import clientRender from './client';
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,27 +80,26 @@ export default class App extends CoreApp {
 
           // Deserialize initial state for the browser
           let initialState = null;
-          let cache = null;
           if (__BROWSER__) {
             const apolloState = document.getElementById('__APOLLO_STATE__');
             if (apolloState) {
               initialState = JSON.parse(unescape(apolloState.textContent));
-              cache = apolloCache.restore(initialState);
             }
           }
 
           if (apolloCache === null) {
-            // Create the client and apollo provider
             const client = getApolloClient(ctx, initialState);
             ctx.element = (
               <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
             );
           } else {        
-            // Create React Context and use cache to create client instead of initialState
+            const cache = apolloCache.restore(initialState);            
             const ApolloContext = React.createContext('ApolloContext');
             const client = getApolloClient(ctx, cache);
             ctx.element = (
-              <ApolloContext.Provider context={ {client, cache} }>{ctx.element}</ApolloContext.Provider>
+              <ApolloContext.Provider cache={cache}>
+                <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
+              </ApolloContext.Provider>
             )
           }
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,16 +72,16 @@ export default class App extends CoreApp {
           
           // Deserialize initial state for the browser
           let initialState = null;
-          let cache = client.cache;
-          let client = getApolloClient(ctx, cache);
                               
           if (__BROWSER__) {
             const apolloState = document.getElementById('__APOLLO_STATE__');
             if (apolloState) {
               initialState = JSON.parse(unescape(apolloState.textContent));             
-              client = getApolloClient(ctx, initialState);
             }
           }
+          
+          let client = getApolloClient(ctx, initialState);
+          const cache = client.cache;
           
           ctx.element = (
             <ApolloContext.Provider cache={cache}>

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ export default class App extends CoreApp {
             }
           }
                           
+          // apollo-universal-client no longer needs to care about the cache
           const cache = apolloCache.restore(initialState);            
           const ApolloContext = React.createContext('ApolloContext');
           const client = getApolloClient(ctx, cache);

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,8 @@ export const GraphQLSchemaToken: Token<string> = createToken(
   'GraphQlSchemaToken'
 );
 
+export const ApolloContext = React.createContext('ApolloContext');
+
 export default class App extends CoreApp {
   constructor(root: Element<*>) {
     const renderer = createPlugin({
@@ -81,9 +83,7 @@ export default class App extends CoreApp {
           let initialState = null;
           let cache = apolloCache;
           let client = getApolloClient(ctx, cache);
-          
-          const ApolloContext = React.createContext('ApolloContext');
-          
+                              
           if (__BROWSER__) {
             const apolloState = document.getElementById('__APOLLO_STATE__');
             if (apolloState) {

--- a/src/index.js
+++ b/src/index.js
@@ -79,17 +79,20 @@ export default class App extends CoreApp {
           
           // Deserialize initial state for the browser
           let initialState = null;
+          let cache = apolloCache;
+          let client = getApolloClient(ctx, cache);
+          
+          const ApolloContext = React.createContext('ApolloContext');
+          
           if (__BROWSER__) {
             const apolloState = document.getElementById('__APOLLO_STATE__');
             if (apolloState) {
               initialState = JSON.parse(unescape(apolloState.textContent));
+              cache = apolloCache.restore(initialState);
+              client = getApolloClient(ctx, cache);
             }
           }
-                          
-          // apollo-universal-client no longer needs to care about the cache
-          const cache = apolloCache.restore(initialState);            
-          const ApolloContext = React.createContext('ApolloContext');
-          const client = getApolloClient(ctx, cache);
+          
           ctx.element = (
             <ApolloContext.Provider cache={cache}>
               <ApolloProvider client={client}>{ctx.element}</ApolloProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ export default class App extends CoreApp {
   constructor(root: Element<*>) {
     const renderer = createPlugin({
       deps: {
-        getApolloClient: ApolloClientToken,
+        getApolloClient: GetApolloClientToken,
         apolloCache: ApolloCacheToken = new InMemoryCache(),
       },
       provides() {

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,6 @@ import clientRender from './client';
 
 type ApolloClientType = mixed;
 
-type TCache = mixed
-
 export type ApolloClient<TInitialState> = (
   ctx: Context,
   initialState: TInitialState
@@ -43,10 +41,6 @@ export const ApolloClientToken: Token<ApolloClient<mixed>> = createToken(
 );
 
 export type ApolloContext<T> = (Context => T) | T;
-
-export type ApolloCacheToken : Token<any> = createToken(
-  'ApolloCacheToken'
-);
 
 export const ApolloContextToken: Token<ApolloContext<mixed>> = createToken(
   'ApolloContextToken'


### PR DESCRIPTION
- Allow `apollo-client` to have `cache` (by default, for example, to enable `link` like `apollo-link-state`).
- Allow children to use `Context.Consumer` to use both `client` and `cache` for life-cycle methods. (for example, for persistence with localStorage)
- Allow `apollo-universal-client` to have `cache` by default will allow better integration interface to use the same `cache` in plugin.