### PR TITLE
Add fusion-tokens as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "fusion-core": "^1.0.0",
+    "fusion-tokens": "^1.1.1",
     "react": "16.x",
     "react-apollo": "^2.0.4",
     "react-dom": "16.x"


### PR DESCRIPTION
fusion-tokens should be a peer dep to ensure the user adds it as a dependency,
and to ensure there is only one version installed.