### PR TITLE
Return DocumentNode when calling `gql`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import CoreApp, {createPlugin, createToken, html, unescape} from 'fusion-core';
 import type {ApolloClient} from 'apollo-client';
+import type {DocumentNode} from 'graphql'
 
 import {ApolloProvider} from 'react-apollo';
 
@@ -117,6 +118,6 @@ export default class App extends CoreApp {
 
 export {ProviderPlugin, ProvidedHOC, Provider};
 
-export function gql(path: string): string {
+export function gql(path: string): DocumentNode {
   throw new Error('fusion-apollo/gql should be replaced at build time');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import React from 'react';
 
 import CoreApp, {createPlugin, createToken, html, unescape} from 'fusion-core';
 import type {ApolloClient} from 'apollo-client';
-import type {DocumentNode} from 'graphql'
+import type {DocumentNode} from 'graphql';
 
 import {ApolloProvider} from 'react-apollo';
 


### PR DESCRIPTION
This makes the `gql` method compatible with react-apollo as it expects the first param of query and mutation hoc. See: https://github.com/apollographql/react-apollo/blob/c706a6aed92541b3f569c6c1a051d24fec880b37/src/query-hoc.tsx#L23